### PR TITLE
Move externals.js to S3.

### DIFF
--- a/catberry_components/head/template.hbs
+++ b/catberry_components/head/template.hbs
@@ -5,5 +5,5 @@
 <link href="/css/bootstrap.min.css" rel="stylesheet">
 <link href="/css/bootstrap-theme.min.css" rel="stylesheet">
 <link href="/css/loader.css" rel="stylesheet">
-<script src="/externals.js"></script>
+<script src="//s3.eu-central-1.amazonaws.com/catberry/example.externals.min.js"></script>
 <script src="/app.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "catberry-example",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Example Application based on Catberry Framework",
 	"main": "./server.js",
 	"browser": {


### PR DESCRIPTION
Now we can use the full power of cache publishing externals.js to S3.